### PR TITLE
Env loading: source .env in Make, python-dotenv in bot/orchestrator; add envcheck & masked logs

### DIFF
--- a/scripts/fix-env.sh
+++ b/scripts/fix-env.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ ! -f .env ]; then
+  echo ".env not found"
+  exit 0
+fi
+
+if command -v dos2unix >/dev/null 2>&1; then
+  dos2unix .env || true
+else
+  sed -i 's/\r$//' .env
+fi
+
+echo "Normalized .env line endings."
+


### PR DESCRIPTION
This PR improves environment handling and diagnostics:

- Makefile
  - Export `.env` for `run` and `bot` targets using `set -a; source .env`.
  - Keep `bot` run as module (`-m connectors.discord.bot`) to avoid import warnings.
  - Add `envcheck` target to print masked Discord and webhook values for quick verification.
  - Add `fix-env` helper target to normalize CRLF line endings in `.env` on WSL.

- Discord Bot
  - Load `.env` and optional `.env.local` via `python-dotenv` at import time.
  - Mask sensitive values (IDs/tokens) in startup logs.
  - Exit with a clear message if `DISCORD_BOT_TOKEN` is missing.

- Orchestrator
  - Load `.env` and optional `.env.local` via `python-dotenv`.
  - Log a concise, masked startup configuration summary, including available providers and presence of provider keys.

Validation checklist:
- `make envcheck` shows masked values for Discord IDs and a masked token.
- `make bot` starts without "Not configured" noise and without the module import warning, and masks the token.
- `make run` loads `.env` and prints masked orchestrator diagnostics.
- If `.env` is missing, the bot exits with a clear error.

Notes:
- `python-dotenv` was already present in both `pyproject.toml` and `requirements.txt`.
