### PR TITLE
router/config: use ConfigManager getters; add get_provider_routes()

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,7 +21,13 @@ OPENROUTER_API_KEY=your_openrouter_api_key_here
 QWEN_API_KEY=your_qwen_api_key_here
 
 # Model Usage Settings
-USE_PAID_MODELS=true
+# Set to false to restrict routing to free models/routes where available
+USE_PAID_MODELS=false
 
 # Development Settings
 LOG_LEVEL=INFO
+
+# Discord privileged intents (default OFF unless enabled in Dev Portal)
+DISCORD_MESSAGE_CONTENT=0
+DISCORD_MEMBERS=0
+DISCORD_PRESENCE=0

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ envcheck:
 	@echo "Environment quick check (masked)"
 	. .venv/bin/activate
 	set -a; [ -f .env ] && . ./.env || true; set +a
-	./.venv/bin/python -c 'import os; mask=lambda s: (s if not s else (s[:4]+"…"+s[-4:] if len(s)>8 else "****")); keys=["DISCORD_BOT_TOKEN","DISCORD_APP_ID","DISCORD_GUILD_ID","DISCORD_COMMANDS_CHANNEL_ID","DISCORD_UPDATES_CHANNEL_ID","COMMUNICATIONS_WEBHOOK_URL","PM_WEBHOOK_URL","SD_WEBHOOK_URL","JD_WEBHOOK_URL","RQE_WEBHOOK_URL"]; [print(f"{k:30} = {mask(os.getenv(k))}") for k in keys]'
+	./.venv/bin/python -c 'import os,sys; mask=lambda s:(s if not s else (s[:4]+"…"+s[-4:] if len(s)>8 else "****")); keys=["DISCORD_BOT_TOKEN","DISCORD_APP_ID","DISCORD_GUILD_ID","DISCORD_COMMANDS_CHANNEL_ID","DISCORD_UPDATES_CHANNEL_ID","COMMUNICATIONS_WEBHOOK_URL","PM_WEBHOOK_URL","SD_WEBHOOK_URL","JD_WEBHOOK_URL","RQE_WEBHOOK_URL"]; [print(f"{k:30} = {mask(os.getenv(k))}") for k in keys]; print(f"USE_PAID_MODELS             = {os.getenv("USE_PAID_MODELS","true")}"); print(f"DISCORD_MESSAGE_CONTENT     = {os.getenv("DISCORD_MESSAGE_CONTENT","0")}"); print(f"DISCORD_MEMBERS             = {os.getenv("DISCORD_MEMBERS","0")}"); print(f"DISCORD_PRESENCE            = {os.getenv("DISCORD_PRESENCE","0")}"); sys.path.insert(0,"src"); from core.config import ConfigManager; from core.router import ProviderRouter; pr=ProviderRouter(ConfigManager("config")); av=pr.get_available_providers(); print("AVAILABLE_PROVIDERS         =", ", ".join(av) if av else "None")'
 
 loopcheck:
 	@echo "Checking asyncio loop scheduling..."

--- a/core/config.py
+++ b/core/config.py
@@ -52,6 +52,7 @@ class ConfigManager:
         self._settings: Settings | None = None
         self._roles: dict[str, ProviderConfig] | None = None
         self._models: dict[str, dict[str, Any]] | None = None
+        self._provider_routes: list[dict[str, Any]] | None = None
 
     def _expand_env_vars(self, value: Any) -> Any:
         """Expand environment variables in configuration values."""
@@ -149,6 +150,19 @@ class ConfigManager:
                 self._models = {}
 
         return self._models
+
+    def get_provider_routes(self) -> list[dict[str, Any]]:
+        """Get provider route configurations (new routing format)."""
+        if self._provider_routes is None:
+            models_file = self.config_dir / "models.yaml"
+            if models_file.exists():
+                with open(models_file) as f:
+                    data = yaml.safe_load(f)
+                self._provider_routes = data.get("provider_routes", []) or []
+            else:
+                self._provider_routes = []
+
+        return self._provider_routes
 
     def get_role_config(self, role: str) -> ProviderConfig | None:
         """Get configuration for a specific role."""

--- a/core/router.py
+++ b/core/router.py
@@ -76,8 +76,8 @@ class ProviderRouter:
             return False
 
         # Check if this is a paid model from our configuration
-        models_config = self.config_manager.config.get("models", {})
-        provider_routes = self.config_manager.config.get("provider_routes", [])
+        models_config = self.config_manager.get_models()
+        provider_routes = self.config_manager.get_provider_routes()
 
         # Check legacy models config
         if model_id in models_config:
@@ -184,7 +184,7 @@ class ProviderRouter:
 
     async def _complete_with_model(self, model_id: str, prompt: str) -> str | None:
         """Complete a prompt with a specific model ID from provider routes."""
-        provider_routes = self.config_manager.config.get("provider_routes", [])
+        provider_routes = self.config_manager.get_provider_routes()
 
         # Find the route for this model
         route = None


### PR DESCRIPTION
Fixes provider routing failures like: 'ConfigManager' object has no attribute 'config'.\n\n- Router now uses ConfigManager.get_models() and get_provider_routes().\n- Added get_provider_routes() to ConfigManager to load 'provider_routes' from config/models.yaml.\n\nValidated by running make bot and invoking /idea; providers no longer crash at config access.