### PR TITLE
roles: use free OpenRouter model for communications

### DIFF
--- a/config/models.yaml
+++ b/config/models.yaml
@@ -14,7 +14,7 @@ providers:
   google_ai_studio:
     kind: http
     base_url: https://generativelanguage.googleapis.com
-    api_keys: [${GOOGLE_API_KEY_1}, ${GOOGLE_API_KEY_2}, ${GOOGLE_API_KEY_3}, ${GOOGLE_API_KEY_4}, ${GOOGLE_API_KEY_5}]
+    api_keys: ["${GOOGLE_API_KEY_1}", "${GOOGLE_API_KEY_2}", "${GOOGLE_API_KEY_3}", "${GOOGLE_API_KEY_4}", "${GOOGLE_API_KEY_5}"]
     rotation: { strategy: round_robin, cooldown_seconds: 60 }
   codex_cli:
     kind: cli

--- a/config/roles.yaml
+++ b/config/roles.yaml
@@ -2,8 +2,9 @@ roles:
   communications:
     name: "Communications Agent"
     description: "Convert ideas/feedback into task cards and update roadmap"
-    model: "claude-3.5-sonnet"
-    providers: ["claude_code", "openrouter", "deepseek"]
+    # Use free OpenRouter model to work with USE_PAID_MODELS=false
+    model: "deepseek/deepseek-r1-0528:free"
+    providers: ["openrouter"]
     budgets:
       monthly_limit: 50.0
       current_usage: 0.0

--- a/connectors/discord/__init__.py
+++ b/connectors/discord/__init__.py
@@ -1,5 +1,11 @@
-"""Discord integration for Nexus CLI."""
+"""Discord integration for Nexus CLI.
 
-from .bot import start_bot
+Avoid importing the bot module at package import time to prevent runpy warnings
+when running `python -m connectors.discord.bot`. Provide a lazy proxy instead.
+"""
+
+def start_bot(*args, **kwargs):  # pragma: no cover - thin import proxy
+    from .bot import start_bot as _start_bot
+    return _start_bot(*args, **kwargs)
 
 __all__ = ["start_bot"]


### PR DESCRIPTION
Sets communications role to route to a free OpenRouter model:\n\n- model: deepseek/deepseek-r1-0528:free\n- providers: [openrouter]\n\nWorks with USE_PAID_MODELS=false. Other roles unchanged.