### PR TITLE
webhooks: post updates from orchestrator; OpenRouter: handle content arrays

### DIFF
--- a/connectors/providers/openrouter.py
+++ b/connectors/providers/openrouter.py
@@ -56,7 +56,20 @@ class OpenrouterProvider(BaseProvider):
 
                 msg = choices[0].get("message") or {}
                 content = msg.get("content")
-                if not content:
+                # Support content as either a string or a list of text parts
+                if isinstance(content, list):
+                    parts = []
+                    for part in content:
+                        # Common shapes: {"type":"text","text":"..."} or {"text":"..."}
+                        if isinstance(part, dict):
+                            txt = part.get("text") or part.get("content")
+                            if txt:
+                                parts.append(str(txt))
+                        elif isinstance(part, str):
+                            parts.append(part)
+                    content = "\n".join(parts).strip()
+
+                if not content or not isinstance(content, str):
                     raise RuntimeError("OpenRouter choice missing message content")
                 return content.strip()
 


### PR DESCRIPTION
- Orchestrator now posts updates to Discord webhooks (from settings) for any role after successful processing.\n- OpenRouter provider supports content as a list of parts, avoiding "choice missing message content" errors for some models.\n\nThis should make non-communications roles visible in #updates when webhooks are configured, and improve reliability with free models.